### PR TITLE
Tweak flags and status; add a bundle.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 This charm is for basic testing with the [snap-store-proxy][].
 
-It requires postgresql and can be deployed with:
+It requires postgresql and can be deployed with the `bundle.yaml` included in
+this repository:
 
 ```yaml
 series: bionic
@@ -10,9 +11,11 @@ applications:
   postgresql:
     charm: cs:postgresql
     num_units: 1
+    constraints: mem=3G
   snap-store-proxy:
-    charm: /path/to/snap-store-proxy
+    charm: /path/to/built/snap-store-proxy
     num_units: 1
+    constraints: mem=3G
     expose: true
 relations:
   - [snap-store-proxy, postgresql:db-admin]
@@ -21,14 +24,15 @@ relations:
 Once deployed, the charm will prompt via status to perform the manual
 registration step using:
 
-```
+```bash
 juju ssh {unit} "sudo snap-proxy register"
 ```
 
-Once registration completes, the status will give you the commands
-to activate the snap store proxy on your machine, which are:
+After registering, you may have to wait up to 5 minutes for the charm to
+acknowledge the registration. Once ready, the status output will give you the
+commands to activate the snap store proxy on your machine, which are:
 
-```
+```bash
 curl -s http://{domain}/v2/auth/store/assertions | sudo snap ack /dev/stdin
 sudo snap set core proxy.store={store_id}
 ```
@@ -36,16 +40,15 @@ sudo snap set core proxy.store={store_id}
 The `{domain}` is the public address of this charm, and the `{store_id}` will
 be included in the status, or can be retrieved using:
 
-```
+```bash
 juju ssh {unit} "snap-proxy status"
 ```
 
 You can then create or delete overrides using the actions:
 
-```
+```bash
 juju run-action --wait {unit} create-override snap=kubectl channel=1.16/stable rev=1202
 juju run-action --wait {unit} delete-override snap=kubectl channel=1.16/stable
 ```
-
 
 [snap-store-proxy]: https://docs.ubuntu.com/snap-store-proxy/en/

--- a/actions/create-override
+++ b/actions/create-override
@@ -4,8 +4,8 @@ from subprocess import run
 from charms.reactive import is_flag_set
 from charmhelpers.core.hookenv import action_get, action_set, action_fail
 
-if not is_flag_set('registered'):
-    action_fail('snap store proxy not registered')
+if not is_flag_set('snap-store-proxy.registered'):
+    action_fail('snap store proxy is not registered')
     raise SystemExit(1)
 
 snap = action_get('snap')

--- a/actions/delete-override
+++ b/actions/delete-override
@@ -4,8 +4,8 @@ from subprocess import run
 from charms.reactive import is_flag_set
 from charmhelpers.core.hookenv import action_get, action_set, action_fail
 
-if not is_flag_set('registered'):
-    action_fail('snap store proxy not registered')
+if not is_flag_set('snap-store-proxy.registered'):
+    action_fail('snap store proxy is not registered')
     raise SystemExit(1)
 
 snap = action_get('snap')

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -1,0 +1,13 @@
+series: bionic
+applications:
+  postgresql:
+    charm: cs:postgresql
+    num_units: 1
+    constraints: mem=3G
+  snap-store-proxy:
+    charm: /home/ubuntu/charms/builds/snap-store-proxy
+    num_units: 1
+    expose: true
+    constraints: mem=3G
+relations:
+  - [snap-store-proxy, postgresql:db-admin]

--- a/layer.yaml
+++ b/layer.yaml
@@ -3,3 +3,5 @@ includes:
   - layer:status
   - layer:snap
   - interface:pgsql
+exclude:
+  - bundle.yaml

--- a/reactive/snap_store_proxy.py
+++ b/reactive/snap_store_proxy.py
@@ -7,23 +7,40 @@ from charmhelpers.core import hookenv
 from charms import layer
 
 
-@when_not('installed')
+@when_not('snap.installed.snap-store-proxy')
 def install():
+    layer.status.maintenance('Installing snap-store-proxy')
     layer.snap.install('snap-store-proxy', channel='candidate')
-    layer.status.waiting('Waiting for Postgres')
-    set_flag('installed')
+
+
+@when_not('db.connected')
+def wait_for_db():
+    try:
+        goal_state = hookenv.goal_state()
+    except NotImplementedError:
+        goal_state = {}
+
+    if 'db' in goal_state.get('relations', {}):
+        layer.status.waiting('Waiting for Postgres')
+    else:
+        layer.status.blocked('Missing postgresql:db-admin relation')
 
 
 @when('db.connected')
+@when_not('snap-store-proxy.db.requested')
 def request_db():
+    layer.status.maintenance('Requesting database')
     db = endpoint_from_name('db')
     db.set_database('snap_store_proxy')
     db.set_extensions('btree_gist')
+    set_flag('snap-store-proxy.db.requested')
 
 
 @when('db.master.available')
-@when_not('configured')
+@when('snap.installed.snap-store-proxy')
+@when_not('snap-store-proxy.configured')
 def configure():
+    layer.status.maintenance('Configuring snap-proxy')
     db = endpoint_from_name('db')
     public_ip = hookenv.unit_public_ip()
     run(['snap-proxy', 'config', f'proxy.db.connection={db.master.uri}'],
@@ -31,22 +48,30 @@ def configure():
     run(['snap-proxy', 'config', f'proxy.domain={public_ip}'],
         check=True)
     run(['snap-proxy', 'generate-keys'], check=True)
+
     hookenv.open_port(80)
-    layer.status.blocked(f'Please run: '
-                         f'juju ssh {hookenv.local_unit()} '
-                         f'"sudo snap-proxy register"')
-    set_flag('configured')
+    set_flag('snap-store-proxy.configured')
 
 
-@when('configured')
-@when_not('registered')
+@when('snap-store-proxy.configured')
+@when_not('snap-store-proxy.registered')
 def check_registration():
-    result = run(['snap-proxy', 'status'], check=True, stdout=PIPE)
-    data = yaml.safe_load(result.stdout.decode('utf8'))
-    if data.get('Store ID'):
+    try:
+        result = run(['snap-proxy', 'status'], check=True, stdout=PIPE)
+    except Exception:
+        layer.status.maintenance('Failed to run "snap-proxy status"; will retry')
+        return
+    else:
+        data = yaml.safe_load(result.stdout.decode('utf8'))
+
+    store_id = data.get('Store ID')
+    if not store_id or 'not registered' in store_id:
+        layer.status.blocked(f'Please run: '
+                             f'juju ssh {hookenv.local_unit()} '
+                             f'"sudo snap-proxy register"')
+    else:
         domain = hookenv.unit_public_ip()
-        store_id = data['Store ID']
         layer.status.active(f'curl -s http://{domain}/v2/auth/store/assertions'
                             f' | sudo snap ack /dev/stdin ; '
                             f'sudo snap set core proxy.store={store_id}')
-        set_flag('registered')
+        set_flag('snap-store-proxy.registered')


### PR DESCRIPTION
I noticed some of the handler timing seemed off.  For example, we might try to run `snap-proxy config` before the snap is installed; we also asked postgres for the same database every hook.  This PR:

- adjusts flags to ensure proper handler order
- adds more accurate status messages
- adds a bundle.yaml for convenient deployment
- minor readme tweaks